### PR TITLE
Ensure output dirs are created so gpb_compile won't fail

### DIFF
--- a/src/rebar_protobuffs_prv.erl
+++ b/src/rebar_protobuffs_prv.erl
@@ -38,10 +38,13 @@ do(State) ->
                     error -> "proto";
                     {ok, Found} -> Found
                 end,
-                InclDir     = filename:join([rebar_app_info:out_dir(AppInfo), "include"]),
+                InclDir     = filename:join([rebar_app_info:dir(AppInfo), "include"]),
                 SrcDir      = filename:join([rebar_app_info:dir(AppInfo), "src"]),
                 InputDir    = filename:join([rebar_app_info:dir(AppInfo), ProtoDir]),
                 FoundFiles  = rebar_utils:find_files(InputDir, ".*\\.proto\$"),
+
+                ok = filelib:ensure_dir(lists:append(InclDir, "/")),
+                ok = filelib:ensure_dir(lists:append(SrcDir, "/")),
 
                 CompileFun  = fun(Source, Opts1) ->
                         do_compile(Source, SrcDir, InclDir, Opts1)


### PR DESCRIPTION
Otherwise `gbp_compile` fails if there is no `include` (or `src`?) dir in the app.

Use `dir` instead of `out_dir` for include dir, so when using a `pre_compile` hook the `gpb_compile` happens in the workdir and the `rebar compile` will be responsible of moving everything to the `_build` directory.
